### PR TITLE
ci: Remove description key

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,4 @@
 name: "Docker"
-description: "Builds the Hedwig docker image"
 
 on:
   push:


### PR DESCRIPTION
I got the docs for workflows and actions mixed up and included a key that's not part of a valid workflow, this removes it.