### PR TITLE
Fix rust workflow for dependabot PRs, update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "bump: "
+      prefix: "bump"
+      prefix-development: "bump"

--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -13,5 +13,10 @@ concurrency:
 
 jobs:
   check:
+    # Workaround for GITHUB_TOKEN being read-only in dependabot PRs, stopping meow-coverage from working
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
     uses: famedly/backend-build-workflows/.github/workflows/rust-workflow.yml@main
     secrets: inherit


### PR DESCRIPTION
This should hopefully fix the problem of coverage not working on dependabot PR CI workflows. Also reconfigures dependabot's commit messages to match our convention.