### PR TITLE
Remove political statement from README to maintain technical neutrality

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ This is a dead simple Push Gateway for a [Matrix.org](https://matrix.org) applic
 - Version endpoint at `GET /version`
 - Prometheus metrics at `GET /metrics`
 
-
-This project name aged badly, trans rights are human rights!
-
 ## Getting Started
 
 ### Hedwig configuration:


### PR DESCRIPTION
This project exists to serve a purely technical purpose (a Matrix push gateway) and should remain free of political or social advocacy. Including partisan statements risks alienating contributors and users who seek an inclusive, apolitical space to collaborate on technical solutions. The README should focus solely on project functionality, setup, and contribution guidelines.

The project name "Hedwig" (a historical reference to messaging owls in fiction) requires no justification beyond its technical role. Let’s keep discussions centered on the push gateway’s implementation, performance, and reliability.
