### PR TITLE
fix: Connecting to Firebase fails with invalid URL, scheme is not http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,8 +551,7 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 [[package]]
 name = "firebae-cm"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac804bbaa48ef316b28144747acb239565bf1513343ebfe2738abfa054ee86d2"
+source = "git+https://github.com/productlabteam/firebae-cm.git#321884829524d3e0d3a5a36720929f2dd794f40e"
 dependencies = [
  "chrono",
  "log",
@@ -923,7 +922,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1640,6 +1639,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
@@ -1647,17 +1647,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2587,6 +2591,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,19 +2636,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ axum = { version = "0.7.5", features = ["macros"] }
 axum-opentelemetry-middleware = { version = "0.3.0", git = "https://github.com/famedly/axum-opentelemetry-middleware.git" }
 color-eyre = "0.6.3"
 config = "0.13.4"
-firebae-cm = "0.1.0"
+firebae-cm = { git = "https://github.com/productlabteam/firebae-cm.git" }
 gcp_auth = "0.8.1"
 opentelemetry = { version = "0.24.0", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.24.1", features = ["metrics", "rt-tokio"] }


### PR DESCRIPTION
Apply backported TLS fix from https://github.com/productlabteam/firebae-cm.git

https://github.com/famedly/hedwig/pull/175 should be merged first