### PR TITLE
feat: validate VoIP devices against a separate app_id prefix

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -12,6 +12,10 @@ server:
 
 hedwig:
   app_id: "org.matrix.awesome_client"
+  # Application ID prefix for VoIP devices (data_message: ios_voip). Must be
+  # the app's real bundle id + ".voip" since it's sent to Apple as the
+  # apns-topic.
+  voip_app_id: "org.matrix.awesome_client.voip"
   # specifies how many attempts at pushing a notification to a device should be made before giving up and reporting the push key as dead
   push_max_retries: 5
   # common fields for notifications sent to FCM and APNS
@@ -51,7 +55,9 @@ hedwig:
   # token, not an FCM token) and apns_key_file_path must be configured.
   apns_headers:
     # https://developer.apple.com/documentation/usernotifications/sending-notification-requests-to-apns#Know-when-to-use-push-types
-    apns_push_type: background
+    # Use "alert" for regular (visible) notifications; "background" suppresses
+    # the banner and skips the client's Notification Service Extension.
+    apns_push_type: alert
     apns_topic: app.bundle.id
     apns_id: null
     apns_priority: null

--- a/src/pusher.rs
+++ b/src/pusher.rs
@@ -38,9 +38,14 @@ use crate::{
 	settings::Settings,
 };
 
-/// Validates that a device's `app_id` matches the configured Hedwig app id.
+/// Validates a device's `app_id`, using `hedwig.voip_app_id` for VoIP
+/// devices and `hedwig.app_id` otherwise.
 fn validate_app_id(device: &Device, settings: &Settings) -> Result<(), HedwigError> {
-	if !device.app_id.starts_with(&settings.hedwig.app_id) {
+	let is_voip = matches!(device.data_message_type(), DataMessageType::IosVoip);
+	let allowed_prefix =
+		if is_voip { &settings.hedwig.voip_app_id } else { &settings.hedwig.app_id };
+
+	if !device.app_id.starts_with(allowed_prefix) {
 		return Err(HedwigError { error: "Invalid app id!".to_owned(), errcode: ErrCode::BadJson });
 	}
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -94,8 +94,13 @@ pub struct FcmNotificationAndroid {
 /// Hedwig configuration
 #[derive(Debug, Deserialize)]
 pub struct Hedwig {
-	/// Application ID
+	/// Application ID prefix for validating regular (non-VoIP) pushers.
 	pub app_id: String,
+	/// Application ID prefix for validating VoIP devices. Kept separate
+	/// from `app_id` since a VoIP device's `app_id` is used verbatim as the
+	/// `apns-topic` (must be the real bundle id + `.voip`), unlike the
+	/// arbitrary `app_id` used for regular routing.
+	pub voip_app_id: String,
 	/// Maximum amount of attempts hedwig should make
 	pub push_max_retries: i64,
 	/// The text to display in a notification (replaces <count> tag with a

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -60,6 +60,7 @@ fn create_test_settings(port: u16) -> Settings {
 
 	let hedwig = settings::Hedwig {
 		app_id: "com.test.app".to_owned(),
+		voip_app_id: "com.test.app.voip".to_owned(),
 		push_max_retries: 3,
 		notification_title: "Test".to_owned(),
 		notification_body: "Test body".to_owned(),

--- a/tests/pusher.rs
+++ b/tests/pusher.rs
@@ -96,6 +96,14 @@ fn setup_server(
 	fcm_sender: Box<dyn FcmSender + Send + Sync>,
 	apns_sender: Option<Box<dyn APNSSender + Send + Sync>>,
 ) -> Result<Router, Report> {
+	setup_server_with_voip_app_id(fcm_sender, apns_sender, None)
+}
+
+fn setup_server_with_voip_app_id(
+	fcm_sender: Box<dyn FcmSender + Send + Sync>,
+	apns_sender: Option<Box<dyn APNSSender + Send + Sync>>,
+	voip_app_id: Option<&str>,
+) -> Result<Router, Report> {
 	let settings = {
 		let log = settings::Log { level: "DEBUG".to_owned() };
 
@@ -103,6 +111,7 @@ fn setup_server(
 
 		let hedwig = settings::Hedwig {
 			app_id: "com.famedly.🦊".to_owned(),
+			voip_app_id: voip_app_id.unwrap_or("com.famedly.🦊").to_owned(),
 			push_max_retries: 4,
 			notification_title: "🦊 <count> 🦊".to_owned(),
 			notification_body: "read the notification pls :c".to_owned(),
@@ -706,6 +715,48 @@ async fn voip_push_without_top_level_notify_via_routes_to_apns(
 	assert_eq!(payload.device_token, "voip_device_token");
 	let json: Value = serde_json::from_str(&payload.to_json_string()?)?;
 	assert_eq!(json["nameCaller"], "Alice");
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn voip_push_uses_separate_voip_app_id() -> Result<(), Box<dyn std::error::Error>> {
+	// A VoIP device's app_id is the real bundle id + ".voip" (required by Apple
+	// as the apns-topic), which doesn't have to share a prefix with the
+	// regular app_id used for FCM/webhook routing. voip_app_id lets both be
+	// validated independently.
+	let (fcm_tx, mut _fcm_rx) = mpsc::channel(1337);
+	let (apns_tx, mut apns_rx) = mpsc::channel(1337);
+	let mut service = setup_server_with_voip_app_id(
+		Box::new(FakeFcmSender(fcm_tx)),
+		Some(Box::new(FakeAPNSSender { tx: apns_tx })),
+		Some("com.famedly.famedlytalk.voip"),
+	)?;
+
+	let msg = json!({
+		"notification": {
+			"counts": { "unread": 1_i32 },
+			"devices": [{
+				"app_id": "com.famedly.famedlytalk.voip",
+				"data": {
+					"format": "event_id_only",
+					"data_message": "ios_voip",
+					"notify_via": "apns"
+				},
+				"pushkey": "voip_device_token",
+				"pushkey_ts": 1_655_896_032_i32
+			}],
+			"room_id": "!room:server",
+			"sender_display_name": "Alice",
+			"prio": "high"
+		}
+	});
+
+	let resp = run_request(&mut service, msg).await?;
+	assert_eq!(&resp, "{\"rejected\":[]}");
+
+	let payload = apns_rx.recv().await.unwrap();
+	assert_eq!(payload.device_token, "voip_device_token");
 
 	Ok(())
 }


### PR DESCRIPTION
A VoIP device's app_id is sent verbatim to Apple as the apns-topic, so it must be the app's real bundle identifier suffixed with ".voip" (e.g. `com.famedly.famedlytalk.voip`). This does not need to share a namespace with the app_id used for regular FCM/webhook routing (e.g. com.famedly.app), but validate_app_id only supported a single configured prefix, so a real client's VoIP pushes would be rejected with "Invalid app id!" whenever the two don't share a prefix.

Add `hedwig.voip_app_id`, checked instead of `hedwig.app_id` for VoIP devices, falling back to app_id when unset for backwards compatibility.

Also fixes config.sample.yaml's `apns_push_type: background`, which suppresses the visible alert and skips the client's Notification Service Extension entirely for regular (non-VoIP) pushes.